### PR TITLE
chore: remove unused imports

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from brownie import ZERO_ADDRESS
 
 

--- a/tests/functional/test_extra_rewards.py
+++ b/tests/functional/test_extra_rewards.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 from brownie import chain, Gauge, ExtraReward
 

--- a/tests/functional/test_gauge.py
+++ b/tests/functional/test_gauge.py
@@ -1,8 +1,5 @@
-from pathlib import Path
 import brownie
-
-import pytest
-from brownie import chain, Gauge, ExtraReward, ZERO_ADDRESS
+from brownie import Gauge, ExtraReward, ZERO_ADDRESS
 
 
 def test_set_reward_manager(create_vault, create_gauge, panda, gov):

--- a/tests/functional/test_gauge_reward_distribution.py
+++ b/tests/functional/test_gauge_reward_distribution.py
@@ -1,6 +1,4 @@
-from pathlib import Path
 import brownie
-
 import pytest
 from brownie import chain, Gauge, ExtraReward
 

--- a/tests/functional/test_ve_yfi_rewards.py
+++ b/tests/functional/test_ve_yfi_rewards.py
@@ -1,8 +1,6 @@
-from pathlib import Path
-
+import brownie
 import pytest
 from brownie import chain
-import brownie
 
 
 def test_ve_yfi_distribution(yfi, ve_yfi, whale, whale_amount, ve_yfi_rewards, gov):

--- a/tests/functional/test_voter.py
+++ b/tests/functional/test_voter.py
@@ -1,6 +1,4 @@
-from pathlib import Path
 import brownie
-
 import pytest
 from brownie import ZERO_ADDRESS, chain, Gauge
 
@@ -61,13 +59,6 @@ def test_vote(
     assert pytest.approx(voter.weights(vault_a)) == ve_yfi.balanceOf(
         whale
     ) / 3 + ve_yfi.balanceOf(shark)
-
-
-from pathlib import Path
-import brownie
-
-import pytest
-from brownie import chain, Gauge
 
 
 def test_vote_delegation(


### PR DESCRIPTION
## Description

[`tests/functional/test_voter.py`](https://github.com/yearn/veYfi/blob/master/tests/functional/test_voter.py#L66) has some imports in the middle of the file. So I just removed this and other unused imports, and made them uniform across the files.

## Checklist

- [ ] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
