### PR TITLE
chore: remove override keyword

### DIFF
--- a/contracts/ExtraReward.sol
+++ b/contracts/ExtraReward.sol
@@ -119,7 +119,6 @@ contract ExtraReward is IExtraReward {
      */
     function rewardCheckpoint(address _account)
         external
-        override
         updateReward(_account)
         returns (bool)
     {
@@ -135,7 +134,6 @@ contract ExtraReward is IExtraReward {
      */
     function getRewardFor(address _account)
         public
-        override
         updateReward(_account)
         returns (bool)
     {
@@ -148,7 +146,7 @@ contract ExtraReward is IExtraReward {
         return true;
     }
 
-    function getReward() external override returns (bool) {
+    function getReward() external returns (bool) {
         getRewardFor(msg.sender);
         return true;
     }

--- a/contracts/Gauge.sol
+++ b/contracts/Gauge.sol
@@ -108,12 +108,7 @@ contract Gauge is IGauge {
     /** @param account to look balance for
      *  @return amount of staked token for an account
      */
-    function balanceOf(address account)
-        external
-        view
-        override
-        returns (uint256)
-    {
+    function balanceOf(address account) external view returns (uint256) {
         return _balances[account];
     }
 

--- a/contracts/GaugeFactory.sol
+++ b/contracts/GaugeFactory.sol
@@ -37,7 +37,7 @@ contract GaugeFactory is IGaugeFactory {
         address manager,
         address ve,
         address veYfiRewardPool
-    ) external override returns (address) {
+    ) external returns (address) {
         address newGauge = _clone(deployedGauge);
         IGauge(newGauge).initialize(
             _vault,


### PR DESCRIPTION
## Description

Removing `override` from a couple of functions.

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
