### PR TITLE
chore: remove .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.sol linguist-language=Solidity
-*.vy linguist-language=Python


### PR DESCRIPTION
## Description
No need to have `.gitattributes` file anymore, because both Vyper and Solidity have github parsers for the language
