### PR TITLE
test: gas estimations for vote delegation

### DIFF
--- a/tests/functional/test_vote_delegation.py
+++ b/tests/functional/test_vote_delegation.py
@@ -49,3 +49,52 @@ def test_delegate(
     delegation = vote_delegation.delegation(whale).dict()
     assert delegation["to"] == panda
     assert delegation["until"] == until + 10
+
+
+def test_delegate_gas(
+    vote_delegation, yfi, ve_yfi, ve_yfi_rewards, whale_amount, whale, panda
+):
+    yfi.approve(ve_yfi, whale_amount, {"from": whale})
+    ve_yfi.create_lock(whale_amount, chain.time() + 3600 * 24 * 365, {"from": whale})
+    # assert(False)
+    vote_delegation.delegate(panda, {"from": whale})  # gas used: 97738
+
+
+def test_delegate_gas_10(
+    accounts, yfi, ve_yfi, ve_yfi_rewards, whale, panda, fish_amount, vote_delegation
+):
+    for i in range(10):
+        accounts.add()
+        yfi.mint(accounts[-1], fish_amount)
+        yfi.approve(ve_yfi, fish_amount, {"from": accounts[-1]})
+        ve_yfi.create_lock(
+            fish_amount, chain.time() + 3600 * 24 * 365, {"from": accounts[-1]}
+        )
+
+    for i in range(11, 20):
+        vote_delegation.delegate(panda, {"from": accounts[i]})
+
+    # assert(False)
+    vote_delegation.delegate(whale, {"from": accounts[19]})  # gas used: 101626
+
+    accounts = accounts[:10]
+
+
+def test_delegate_gas_100(
+    accounts, yfi, ve_yfi, ve_yfi_rewards, whale, panda, fish_amount, vote_delegation
+):
+    for i in range(100):
+        accounts.add()
+        yfi.mint(accounts[-1], fish_amount)
+        yfi.approve(ve_yfi, fish_amount, {"from": accounts[-1]})
+        ve_yfi.create_lock(
+            fish_amount, chain.time() + 3600 * 24 * 365, {"from": accounts[-1]}
+        )
+
+    for i in range(11, 110):
+        vote_delegation.delegate(panda, {"from": accounts[i]})
+
+    # assert(False)
+    vote_delegation.delegate(whale, {"from": accounts[109]})  # gas used: 269476
+
+    accounts = accounts[:10]


### PR DESCRIPTION
## Description

Gas estimation tests for vote delegation. These 3 tests do gas estimation of changing the delegation for 1 - 10 - 100 delegates.

To estimate gas for the last `delegate()` function, I run these tests by uncommenting the `assert(False)` statements. Then make the last `delegate()` call in the interactive mode.

Please let me know if there is a way we can directly compute the gas consumed by the last `delegate()` call.

Fixes #63 

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
