### PR TITLE
fix: make sure _veToken isn't zero

### DIFF
--- a/contracts/Gauge.sol
+++ b/contracts/Gauge.sol
@@ -105,9 +105,10 @@ contract Gauge is BaseGauge, IGauge {
         );
     }
 
-    function setVe(address _ve) external onlyOwner {
-        veToken = _ve;
-        emit UpdatedVeToken(_ve);
+    function setVe(address _veToken) external onlyOwner {
+        require(address(_veToken) != address(0x0), "_veToken 0x0 address");
+        veToken = _veToken;
+        emit UpdatedVeToken(_veToken);
     }
 
     /** @return total of the staked vault token

--- a/contracts/VeYfiRewards.sol
+++ b/contracts/VeYfiRewards.sol
@@ -23,12 +23,14 @@ contract VeYfiRewards is BaseGauge {
         address _owner
     ) {
         __initialize(_rewardToken, _owner);
+        require(address(_veToken) != address(0x0), "_veToken 0x0 address");
         veToken = _veToken;
     }
 
-    function setVe(address _ve) external onlyOwner {
-        veToken = _ve;
-        emit UpdatedVeToken(_ve);
+    function setVe(address _veToken) external onlyOwner {
+        require(address(_veToken) != address(0x0), "_veToken 0x0 address");
+        veToken = _veToken;
+        emit UpdatedVeToken(_veToken);
     }
 
     function _updateReward(address account) internal override {


### PR DESCRIPTION
## Description

Make sure _veToken isn't zero
## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
