### PR TITLE
fix: duration should be updated

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,8 @@ jobs:
     - uses: ApeWorX/github-action@v1
 
     - name: Compile contracts
-      run: ape compile -f --size
+      # TODO: Force recompiles until ape compile caching is fixed
+      run: ape compile --force --size
 
     # Needed to use hardhat
     - name: Setup node.js

--- a/contracts/BaseGauge.sol
+++ b/contracts/BaseGauge.sol
@@ -79,6 +79,7 @@ abstract contract BaseGauge is IBaseGauge, Ownable, Initializable {
             uint256 remaining = periodFinish - block.timestamp;
             uint256 leftover = remaining * rewardRate;
             rewardRate = leftover / newDuration;
+            periodFinish = block.timestamp + newDuration;
         }
         duration = newDuration;
         emit DurationUpdated(newDuration, rewardRate);

--- a/contracts/BaseGauge.sol
+++ b/contracts/BaseGauge.sol
@@ -46,7 +46,11 @@ abstract contract BaseGauge is IBaseGauge, Ownable, Initializable {
     );
     event Sweep(address indexed token, uint256 amount);
 
-    event DurationUpdated(uint256 duration, uint256 rewardRate);
+    event DurationUpdated(
+        uint256 duration,
+        uint256 rewardRate,
+        uint256 periodFinish
+    );
 
     function _newEarning(address) internal view virtual returns (uint256);
 
@@ -82,7 +86,7 @@ abstract contract BaseGauge is IBaseGauge, Ownable, Initializable {
             periodFinish = block.timestamp + newDuration;
         }
         duration = newDuration;
-        emit DurationUpdated(newDuration, rewardRate);
+        emit DurationUpdated(newDuration, rewardRate, periodFinish);
     }
 
     /**

--- a/tests/functional/test_gauge.py
+++ b/tests/functional/test_gauge.py
@@ -151,6 +151,7 @@ def test_set_duration(create_vault, create_gauge, yfi, gov):
     time = chain.blocks.head.timestamp
     gauge.setDuration(14 * 3600 * 24, sender=gov)
 
+    assert pytest.approx(rate / 2, rel=10e-3) == gauge.rewardRate()
+    assert gauge.duration() == 14 * 3600 * 24
     assert gauge.periodFinish() != finish
     assert pytest.approx(gauge.periodFinish()) == time + 14 * 3600 * 24
-    assert pytest.approx(rate / 2) == gauge.rewardRate()


### PR DESCRIPTION
## Description

If the duration isn't updated it could cause the distribution of tokens at the new rate for a longer period of time than planned. If time is increased some tokens will be "lost".


## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
