### PR TITLE
remove duplicate update to account's boosted balance

### DIFF
--- a/contracts/Gauge.sol
+++ b/contracts/Gauge.sol
@@ -517,7 +517,6 @@ contract Gauge is BaseGauge, IGauge {
         updateReward(msg.sender)
         returns (bool)
     {
-        _balances[msg.sender].boostedBalance = _boostedBalanceOf(msg.sender);
         _getReward(msg.sender, _lock, _claimExtras);
         return true;
     }


### PR DESCRIPTION
## Description

This PR removes a duplicate update to each account's boostedBalance when calling getReward(bool,bool).

boostedBalance is updated in _getReward(address,bool,bool), so there's no need to update it in getReward(bool,bool) as well. 


## Checklist

- [x] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [x] I have followed commitlint guidelines 
- [x] I have rebased my changes to the latest version of the main branch
