### PR TITLE
chore: use same event for rewards deletion

### DIFF
--- a/contracts/Gauge.sol
+++ b/contracts/Gauge.sol
@@ -63,7 +63,6 @@ contract Gauge is BaseGauge, IGauge {
     event Withdrawn(address indexed user, uint256 amount);
     event AddedExtraReward(address indexed reward);
     event DeletedExtraRewards(address[] rewards);
-    event RemovedExtraReward(address indexed reward);
     event UpdatedRewardManager(address indexed rewardManager);
     event UpdatedVeToken(address indexed ve);
     event TransferedQueuedPenalty(uint256 transfered);
@@ -214,7 +213,9 @@ contract Gauge is BaseGauge, IGauge {
             }
         }
         require(index != type(uint256).max, "extra reward not found");
-        emit RemovedExtraReward(_extraReward);
+        address[] memory toDelete = new address[](1);
+        toDelete[0] = _extraReward;
+        emit DeletedExtraRewards(toDelete);
         extraRewards[index] = extraRewards[extraRewards.length - 1];
         extraRewards.pop();
         return true;


### PR DESCRIPTION
## Description

Use the same event for single and multiple rewards deletions. I am not sure that's something we should change @rareweasel 

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
