### PR TITLE
fix: balance missmatch

### DIFF
--- a/contracts/interfaces/IVotingYFI.sol
+++ b/contracts/interfaces/IVotingYFI.sol
@@ -10,11 +10,11 @@ interface IVotingYFI is IERC20 {
 
     function totalSupply() external view returns (uint256);
 
-    function locked(address user) external view returns (LockedBalance memory);
+    function locked(address _user) external view returns (LockedBalance memory);
 
     function modify_lock(
-        uint256 amount,
-        uint256 unlock_time,
-        address user
+        uint256 _amount,
+        uint256 _unlock_time,
+        address _user
     ) external;
 }

--- a/contracts/interfaces/IVotingYFI.sol
+++ b/contracts/interfaces/IVotingYFI.sol
@@ -10,22 +10,11 @@ interface IVotingYFI is IERC20 {
 
     function totalSupply() external view returns (uint256);
 
-    function locked__end(address) external view returns (uint256);
-
-    function locked(address) external view returns (LockedBalance memory);
+    function locked(address user) external view returns (LockedBalance memory);
 
     function modify_lock(
-        uint256,
-        uint256,
-        address
+        uint256 amount,
+        uint256 unlock_time,
+        address user
     ) external;
-
-    function migration() external view returns (bool);
-
-    function user_point_epoch(address) external view returns (uint256);
-
-    function user_point_history__ts(address, uint256)
-        external
-        view
-        returns (uint256);
 }

--- a/tests/functional/test_voting_escrow.py
+++ b/tests/functional/test_voting_escrow.py
@@ -43,6 +43,7 @@ def test_over_four_years(chain, accounts, yfi, ve_yfi):
     chain.pending_timestamp += WEEK
 
     assert approx(ve_yfi.totalSupply(), rel=10e-14) == ve_yfi.balanceOf(alice)
+    assert ve_yfi.totalSupply() >= ve_yfi.balanceOf(alice)
 
 
 def test_voting_powers(chain, accounts, yfi, ve_yfi):

--- a/tests/functional/test_voting_escrow.py
+++ b/tests/functional/test_voting_escrow.py
@@ -68,20 +68,23 @@ def test_lock_slightly_over_limit_is_rounded_down(
     ve_yfi.modify_lock(amount, unlock_time, sender=alice)  # 4 years ++
     assert ve_yfi.point_history(alice.address, 1).slope == 0
     assert ve_yfi.balanceOf(alice) == amount
-    assert ve_yfi.slope_changes(ve_yfi, (chain.blocks.head.timestamp // WEEK +1) * WEEK) != 0
-    assert ve_yfi.slope_changes(ve_yfi, (chain.blocks.head.timestamp // WEEK +1) * WEEK)  == ve_yfi.slope_changes(alice, (chain.blocks.head.timestamp // WEEK +1) * WEEK) 
+    assert (
+        ve_yfi.slope_changes(ve_yfi, (chain.blocks.head.timestamp // WEEK + 1) * WEEK)
+        != 0
+    )
+    assert ve_yfi.slope_changes(
+        ve_yfi, (chain.blocks.head.timestamp // WEEK + 1) * WEEK
+    ) == ve_yfi.slope_changes(alice, (chain.blocks.head.timestamp // WEEK + 1) * WEEK)
     chain.pending_timestamp += 2 * DAY
     chain.mine()
-    ve_yfi.modify_lock(amount, 0, sender=alice) # lock some more
+    ve_yfi.modify_lock(amount, 0, sender=alice)  # lock some more
     assert ve_yfi.balanceOf(alice) == amount * 2
     chain.pending_timestamp += WEEK
     chain.mine()
     assert ve_yfi.balanceOf(alice) < amount * 2
 
 
-def test_lock_over_limit_goes_to_zero(
-    chain, accounts, yfi, ve_yfi, setup_time
-):
+def test_lock_over_limit_goes_to_zero(chain, accounts, yfi, ve_yfi, setup_time):
     setup_time()
 
     alice = accounts[0]
@@ -94,11 +97,15 @@ def test_lock_over_limit_goes_to_zero(
     ve_yfi.modify_lock(amount, unlock_time, sender=alice)  # 4 years ++
     assert ve_yfi.point_history(alice.address, 1).slope == 0
     assert ve_yfi.balanceOf(alice) == amount
-    assert ve_yfi.slope_changes(ve_yfi, (chain.blocks.head.timestamp // WEEK +1) * WEEK) != 0
+    assert (
+        ve_yfi.slope_changes(ve_yfi, (chain.blocks.head.timestamp // WEEK + 1) * WEEK)
+        != 0
+    )
     chain.pending_timestamp += MAXTIME + WEEK
     chain.mine()
     assert ve_yfi.balanceOf(alice) == 0
     assert ve_yfi.totalSupply() == 0
+
 
 def test_voting_powers(chain, accounts, yfi, ve_yfi):
     """


### PR DESCRIPTION
## Description

- Fix end of slope not set _chainsecurity report_
- Fix total supply and user balance missmatch
- statemind: veYFI balance might not decrease
- chainsecurity: 5.3 Kink Timestamp Can Be Set to a Past Timestamp

There is still a little mismatch between the user balance and the total supply.

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
