### PR TITLE
fix: total supply can't look in past epochs

### DIFF
--- a/contracts/VotingYFI.vy
+++ b/contracts/VotingYFI.vy
@@ -477,6 +477,8 @@ def totalSupply(ts: uint256 = block.timestamp) -> uint256:
     @return Total voting power
     """
     epoch: uint256 = self.epoch[self]
+    if ts != block.timestamp:
+        epoch = self.find_epoch_by_timestamp(self, ts, epoch)
     last_point: Point = self.point_history[self][epoch]
     last_point = self.replay_slope_changes(self, last_point, ts)
     return convert(last_point.bias, uint256)

--- a/tests/functional/test_voting_escrow.py
+++ b/tests/functional/test_voting_escrow.py
@@ -435,6 +435,7 @@ def test_early_exit(chain, accounts, yfi, ve_yfi):
     assert point_history_4["bias"] == 0
     assert point_history_4["slope"] == 0
 
+
 def test_total_supply_in_the_past(chain, accounts, yfi, ve_yfi, setup_time):
     setup_time()
 

--- a/tests/functional/test_voting_escrow.py
+++ b/tests/functional/test_voting_escrow.py
@@ -434,3 +434,21 @@ def test_early_exit(chain, accounts, yfi, ve_yfi):
     assert point_history_4["ts"] == chain.blocks.head.timestamp
     assert point_history_4["bias"] == 0
     assert point_history_4["slope"] == 0
+
+def test_total_supply_in_the_past(chain, accounts, yfi, ve_yfi, setup_time):
+    setup_time()
+
+    alice = accounts[0]
+    amount = 1000 * 10**18
+    yfi.mint(alice, amount * 20, sender=alice)
+    yfi.approve(ve_yfi.address, amount * 20, sender=alice)
+
+    now = chain.blocks.head.timestamp
+    unlock_time = now + MAXTIME
+    ve_yfi.modify_lock(amount, unlock_time, sender=alice)
+    checkpoint = chain.blocks.head.timestamp
+    checkpoint_total_supply = ve_yfi.totalSupply()
+
+    chain.pending_timestamp += WEEK
+    ve_yfi.modify_lock(amount, 0, sender=alice)  # lock some more
+    assert checkpoint_total_supply == ve_yfi.totalSupply(checkpoint)


### PR DESCRIPTION
## Description

The totalSupply for a ts prior to the last epoch will fail, this is to fix it.

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
