### PR TITLE
fix: add replay to getPriorVotes

### DIFF
--- a/contracts/VotingYFI.vy
+++ b/contracts/VotingYFI.vy
@@ -478,13 +478,8 @@ def getPriorVotes(user: address, height: uint256) -> uint256:
     if d_block != 0:
         block_time += d_t * (height - point_0.blk) / d_block
 
-    upoint.bias -= upoint.slope * convert(block_time - upoint.ts, int128)
-    if upoint.bias >= 0:
-        return convert(upoint.bias, uint256)
-    else:
-        return 0
-
-
+    upoint = self.replay_slope_changes(user, upoint, block_time)
+    return convert(upoint.bias, uint256)
 @view
 @external
 def totalSupply(ts: uint256 = block.timestamp) -> uint256:

--- a/tests/functional/test_voting_escrow.py
+++ b/tests/functional/test_voting_escrow.py
@@ -71,6 +71,24 @@ def test_lock_slightly_over_limit_is_rounded_down(chain, accounts, yfi, ve_yfi):
     assert ve_yfi.balanceOf(alice) < (amount * 2) // MAXTIME * MAXTIME
 
 
+def test_get_prior_votes(chain, accounts, yfi, ve_yfi):
+    alice = accounts[0]
+    amount = 1000 * 10**18
+    power = amount // MAXTIME * MAXTIME
+    yfi.mint(alice, amount * 20, sender=alice)
+    yfi.approve(ve_yfi.address, amount * 20, sender=alice)
+
+    now = chain.blocks.head.timestamp
+    unlock_time = now + MAXTIME + WEEK + 4
+    ve_yfi.modify_lock(amount, unlock_time, sender=alice)  # 4 years ++
+
+    for _ in range(5 * 7 * 24):
+        chain.pending_timestamp += H - 1
+        chain.mine()
+
+    assert ve_yfi.getPriorVotes(alice, chain.blocks.head.number) < power
+
+
 def test_lock_over_limit_goes_to_zero(chain, accounts, yfi, ve_yfi):
     alice = accounts[0]
     amount = 1000 * 10**18


### PR DESCRIPTION
## Description

The getPriorVotes function in VotingYFI calculates a user's bias based on the last recorded point's slope. It does not call replay_slope_changes, which would apply slope changes (kinks) that happened since the last user checkpoint.

As a result, getPriorVotes will incorrectly return a voting power that is too high if the user has a kink that is in-between the last user checkpoint and the block height on which getPriorVotes is called.
Fixes # (issue)

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
