### PR TITLE
fix: remove not necessary zero variable

### DIFF
--- a/contracts/RewardPool.vy
+++ b/contracts/RewardPool.vy
@@ -161,8 +161,7 @@ def _checkpoint_total_supply():
                 # If the point is at 0 epoch, it can actually be earlier than the first deposit
                 # Then make dt 0
                 dt = convert(t - pt.ts, int128)
-            zero: int128 = 0
-            self.ve_supply[t] = convert(max(pt.bias - pt.slope * dt, zero), uint256)
+            self.ve_supply[t] = convert(max(pt.bias - pt.slope * dt, 0), uint256)
         t += WEEK
 
     self.time_cursor = t


### PR DESCRIPTION
## Description

Prior to vyper 0.3.4, `0` defaulted to uint256 which was forcing us to create a zero variable to compare.

Fixes # (issue)

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
