### PR TITLE
fix: limit lock duration to prevent replay issues

### DIFF
--- a/tests/functional/test_ve_yfi_decrease.py
+++ b/tests/functional/test_ve_yfi_decrease.py
@@ -16,7 +16,7 @@ def bob(accounts, yfi, ve_yfi):
     yfi.mint(bob, AMOUNT * 20, sender=bob)
     yfi.approve(ve_yfi.address, AMOUNT * 20, sender=bob)
     now = chain.blocks.head.timestamp
-    unlock_time = now + MAXTIME * 3
+    unlock_time = now + WEEK * 520
     ve_yfi.modify_lock(AMOUNT, unlock_time, sender=bob)
     yield bob
 

--- a/tests/functional/test_voting_escrow.py
+++ b/tests/functional/test_voting_escrow.py
@@ -441,3 +441,15 @@ def test_total_supply_in_the_past(chain, accounts, yfi, ve_yfi):
     chain.pending_timestamp += WEEK
     ve_yfi.modify_lock(amount, 0, sender=alice)  # lock some more
     assert checkpoint_total_supply == ve_yfi.totalSupply(checkpoint)
+
+
+def test_lock_cant_exceed_reply_range(chain, accounts, yfi, ve_yfi):
+    alice = accounts[0]
+    amount = 1000 * 10**18
+    power = amount // MAXTIME * MAXTIME
+    yfi.mint(alice, amount * 20, sender=alice)
+    yfi.approve(ve_yfi.address, amount * 20, sender=alice)
+    now = chain.blocks.head.timestamp
+    unlock_time = now + 530 * WEEK
+    with ape.reverts():
+        ve_yfi.modify_lock(amount, unlock_time, sender=alice)


### PR DESCRIPTION
## Description

test failing on master:

```
def test_lock_exceed_replay_slope_changes_range(chain, accounts, yfi, ve_yfi):
    alice = accounts[0]
    amount = 1000 * 10**18
    power = amount // MAXTIME * MAXTIME
    yfi.mint(alice, amount * 20, sender=alice)
    yfi.approve(ve_yfi.address, amount * 20, sender=alice)
    now = chain.blocks.head.timestamp
    unlock_time = now + MAXTIME + 501 * WEEK
    ve_yfi.modify_lock(amount, unlock_time, sender=alice)
    chain.pending_timestamp += MAXTIME + 502 * WEEK
    chain.mine()
    assert ve_yfi.balanceOf(alice) == 0
```

Make sure lock unlock is within range of the replay_slope_changes function.

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
